### PR TITLE
Allow configurable custom email templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,40 +8,54 @@ The package can be installed as:
 
   1. Add `shield_notifier` to your list of dependencies in `mix.exs`:
 
-    ```elixir
-    def deps do
-      [{:shield_notifier, "~> 0.2"}]
-    end
-    ```
+```elixir
+def deps do
+  [{:shield_notifier, "~> 0.2"}]
+end
+```
 
   2. Ensure `shield_notifier` is started before your application:
 
-    ```elixir
-    def application do
-      [applications: [:shield_notifier]]
-    end
-    ```
+```elixir
+def application do
+  [applications: [:shield_notifier]]
+end
+```
 
   3. Add the following lines to your config:
 
-    ```elixir
-    config :shield_notifier,
-      channels: %{
-        email: %{
-          from: %{
-            name: {:system, "APP_NAME", "Shield Notifier"},
-            email: {:system, "APP_FROM_EMAIL", "no-reply@localhost"}
-          }
-        }
+```elixir
+config :shield_notifier,
+  channels: %{
+    email: %{
+      from: %{
+        name: {:system, "APP_NAME", "Shield Notifier"},
+        email: {:system, "APP_FROM_EMAIL", "no-reply@localhost"}
       }
-    ```
+    }
+  },
+  templates: %{
+    confirmation: %{
+      subject: "Email Confirmation",
+      body: "<path_to_your_template>"
+    },
+    recover_password: %{
+      subject: "Password Recovery",
+      body: "<path_to_your_template>"
+    }
+  }
+```
+
+The `templates` key is optional and may be left out. It is possible to only
+override a single template by only specifying it.
+
   4. Add your favorite Bamboo adapter config for prod env as below
 
-    ```elixir
-    config :shield_notifier, Shield.Notifier.Mailer,
-      adapter: Bamboo.SendgridAdapter,
-      api_key: SYSTEM.get_env("SENDGRID_API_KEY")
-    ```
+```elixir
+config :shield_notifier, Shield.Notifier.Mailer,
+  adapter: Bamboo.SendgridAdapter,
+  api_key: SYSTEM.get_env("SENDGRID_API_KEY")
+```
 
 ## Usage
 
@@ -73,6 +87,45 @@ If you need to create your own channels, you can create channels by using `Shiel
 
 ```elixir
 deliver(recipients :: list, template :: atom, data :: any) :: any
+```
+
+### Custom Templates
+
+A template is a simple text file with the body of the email. Each template will
+be resolved with data specific to the email at hand. To specify data
+replacement use `{{variable}}` in the template.
+
+#### Custom Confirmaiton Template
+
+It may use the following variables:
+  * `identity` the email address of the recipient.
+  * `confirmation_url` the url the recipient must visit to confirm its account.
+
+Default template:
+```
+Welcome {{identity}}!
+
+You can confirm your account through the link below:
+
+[Confirm my account]({{confirmation_url}})
+```
+
+#### Custom Recover Password Template
+
+It may use the following variables:
+  * `identity` the email address of the recipient.
+  * `recover_password_url` the url the recipient must visit to reset the password.
+
+Default template:
+```
+Hello {{identity}}!
+
+Someone has requested a link to change your password, and you can do this through the link below.
+
+[Change my password]({{recover_password_url}})
+
+If you didn't request this, please ignore this email.
+Your password won't change until you access the link above and create a new one.
 ```
 
 ## Contributing

--- a/config/config.exs
+++ b/config/config.exs
@@ -10,6 +10,16 @@ config :shield_notifier,
         email: {:system, "APP_FROM_EMAIL", "no-reply@localhost"}
       }
     }
+  },
+  templates: %{
+    confirmation: %{
+      subject: "Email Confirmation",
+      body: Path.join(__DIR__, "../priv/templates/confirmation_template.txt")
+    },
+    recover_password: %{
+      subject: "Password Recovery",
+      body: Path.join(__DIR__, "../priv/templates/recover_password_template.txt")
+    }
   }
 
 import_config "#{Mix.env}.exs"

--- a/config/test.exs
+++ b/config/test.exs
@@ -2,3 +2,15 @@ use Mix.Config
 
 config :shield_notifier, Shield.Notifier.Mailer,
   adapter: Bamboo.TestAdapter
+
+config :shield_notifier,
+  templates: %{
+    confirmation: %{
+      subject: "Test confirmation mail",
+      body: Path.join(__DIR__, "../test/notifier/channels/files/confirmation_template.txt")
+    },
+    recover_password: %{
+      subject: "Test recover password mail",
+      body: Path.join(__DIR__, "../test/notifier/channels/files/recover_password_template.txt")
+    }
+  }

--- a/lib/notifier/channels/email.ex
+++ b/lib/notifier/channels/email.ex
@@ -6,7 +6,17 @@ defmodule Shield.Notifier.Channel.Email do
 
   @behaviour Shield.Notifier.Channel
 
-  @email_templates Application.get_env(:shield_notifier, :templates)
+  @default_templates %{
+    confirmation: %{
+      subject: "Email Confirmation",
+      body: Path.join(Application.app_dir(:shield_notifier), "priv/templates/confirmation_template.txt")
+    },
+    recover_password: %{
+      subject: "Password Recovery",
+      body: Path.join(Application.app_dir(:shield_notifier), "priv/templates/recover_password_template.txt")
+    }
+  }
+  @email_templates Application.get_env(:shield_notifier, :templates, @default_templates)
     |> Enum.map(fn {type, template} -> {type, Map.update!(template, :body, &File.read!/1)} end)
     |> Map.new
 

--- a/lib/notifier/channels/email.ex
+++ b/lib/notifier/channels/email.ex
@@ -16,7 +16,7 @@ defmodule Shield.Notifier.Channel.Email do
       body: Path.join(Application.app_dir(:shield_notifier), "priv/templates/recover_password_template.txt")
     }
   }
-  @email_templates Application.get_env(:shield_notifier, :templates, @default_templates)
+  @email_templates Map.merge(@default_templates, Application.get_env(:shield_notifier, :templates, %{}))
     |> Enum.map(fn {type, template} -> {type, Map.update!(template, :body, &File.read!/1)} end)
     |> Map.new
 

--- a/priv/templates/confirmation_template.txt
+++ b/priv/templates/confirmation_template.txt
@@ -1,0 +1,5 @@
+Welcome {{identity}}!
+
+You can confirm your account through the link below:
+
+[Confirm my account]({{confirmation_url}})

--- a/priv/templates/recover_password_template.txt
+++ b/priv/templates/recover_password_template.txt
@@ -1,0 +1,8 @@
+Hello {{identity}}!
+
+Someone has requested a link to change your password, and you can do this through the link below.
+
+[Change my password]({{recover_password_url}})
+
+If you didn't request this, please ignore this email.
+Your password won't change until you access the link above and create a new one.

--- a/test/notifier/channels/email_test.exs
+++ b/test/notifier/channels/email_test.exs
@@ -2,6 +2,11 @@ defmodule Shield.Notifier.Channel.EmailTest do
   use ExUnit.Case
   use Bamboo.Test
 
+  @confirmation_body [__DIR__, "files/confirmation_body.txt"] |> Path.join |> File.read!
+  @confirmation_subject Application.get_env(:shield_notifier, :templates)[:confirmation][:subject]
+  @recover_password_body [__DIR__, "files/recover_password_body.txt"] |> Path.join |> File.read!
+  @recover_password_subject Application.get_env(:shield_notifier, :templates)[:recover_password][:subject]
+
   test "confirmation email" do
     to = "to@example.com"
     data = %{identity: to,
@@ -12,10 +17,8 @@ defmodule Shield.Notifier.Channel.EmailTest do
       |> List.first
 
     assert email.to == [{to, to}]
-    assert email.subject == "Email Confirmation"
-    assert email.text_body =~ "Welcome to@example.com!\n\nYou can confirm your \
-account through the link below:\n\n[Confirm my account]\
-(https://example.com/confirm-email?token=12345)"
+    assert email.subject == @confirmation_subject
+    assert email.text_body =~ @confirmation_body
   end
 
   test "recover password email" do
@@ -28,12 +31,7 @@ account through the link below:\n\n[Confirm my account]\
       |> List.first
 
     assert email.to == [{to, to}]
-    assert email.subject == "Password Recovery"
-    assert email.text_body =~ "Hello to@example.com!\n\n\
-Someone has requested a link to change your password, and you can do this \
-through the link below.\n\n[Change my password](https://example.com/\
-recover-password?token=12345)\n\nIf you didn't request this, please \
-ignore this email.\nYour password won't change until you access the link \
-above and create a new one."
+    assert email.subject == @recover_password_subject
+    assert email.text_body =~ @recover_password_body
   end
 end

--- a/test/notifier/channels/files/confirmation_body.txt
+++ b/test/notifier/channels/files/confirmation_body.txt
@@ -1,0 +1,7 @@
+Welcome to@example.com!
+
+Test confirmation template.
+
+You can confirm your account through the link below:
+
+[Confirm my account](https://example.com/confirm-email?token=12345)

--- a/test/notifier/channels/files/confirmation_template.txt
+++ b/test/notifier/channels/files/confirmation_template.txt
@@ -1,0 +1,7 @@
+Welcome {{identity}}!
+
+Test confirmation template.
+
+You can confirm your account through the link below:
+
+[Confirm my account]({{confirmation_url}})

--- a/test/notifier/channels/files/recover_password_body.txt
+++ b/test/notifier/channels/files/recover_password_body.txt
@@ -1,0 +1,5 @@
+Hello to@example.com!
+
+Test recover password template.
+
+[Change my password](https://example.com/recover-password?token=12345)

--- a/test/notifier/channels/files/recover_password_template.txt
+++ b/test/notifier/channels/files/recover_password_template.txt
@@ -1,0 +1,5 @@
+Hello {{identity}}!
+
+Test recover password template.
+
+[Change my password]({{recover_password_url}})


### PR DESCRIPTION
Let user specify custom email templates.

Templates are specified in a text file to reduce clutter in config file and read at compile time to reduce overhead from disk IO.